### PR TITLE
Removed call to setup, which can cause problems

### DIFF
--- a/register_service_account/register_service_account.py
+++ b/register_service_account/register_service_account.py
@@ -3,8 +3,6 @@ from common import *
 
 
 def main():
-    setup()
-
     # The main argument parser
     parser = DefaultArgsParser(description="Register a service account for use in FireCloud.")
 


### PR DESCRIPTION
This script was calling setup(), which all other scripts do - but since it's a script to register and only uses the svc account credentials, it doesn't make sense to print who you are authed is.  Someone was running this with an account that wasn't registered with FC and got an error, but it would have run if setup was not called.