### PR TITLE
Pass in admin account as a parameter

### DIFF
--- a/scripts/cleanup_clusters/cleanup_clusters.sh
+++ b/scripts/cleanup_clusters/cleanup_clusters.sh
@@ -2,6 +2,7 @@
 
 ACTION=$1
 LOG_SUFFIX=$2
+USER=$3
 
 if [[ "$ACTION" != "list" && "$ACTION" != "delete" ]]
 then
@@ -15,18 +16,20 @@ fi
 TEST_ADMIN_SUFFIX='@test.firecloud.org'
 QUALITY_ADMIN_SUFFIX='@quality.firecloud.org'
 
-USER=$(gcloud auth list | grep '*' | tr -s ' ' | cut -f2 -d' ')
-echo "You are currently logged in as $USER"
+echo "Running with user $USER"
 
 if [[ "$USER" != *"$TEST_ADMIN_SUFFIX" && "$USER" != *"$QUALITY_ADMIN_SUFFIX" ]]
 then
     echo "***ERROR***"
     echo "This script is intended for running only by test-domain and quality-domain admins."
-    echo "Please run 'gcloud auth login' with an email ending in $TEST_ADMIN_SUFFIX or $QUALITY_ADMIN_SUFFIX and try again."
+    echo "Please pass in an email an email ending in $TEST_ADMIN_SUFFIX or $QUALITY_ADMIN_SUFFIX and try again."
+    echo "You many need to 'gcloud auth login <email>' as that user first."
     echo "***ERROR***"
 
     exit 2
 fi
+
+GCLOUD_CMD="gcloud --account $USER"
 
 # Leonardo only creates clusters in this region
 CLUSTER_REGION='us-central1'
@@ -34,17 +37,17 @@ CLUSTER_REGION='us-central1'
 TODAY=$(date +"%Y-%m-%d")
 LOG_FILE="deletions-$TODAY-$LOG_SUFFIX.csv"
 
-for proj in `gcloud projects list --format='table(NAME)[no-heading]'`
+for proj in `$GCLOUD_CMD projects list --format='table(NAME)[no-heading]'`
     do
         # does this project have dataproc enabled? calling 'gcloud dataproc' will error if not
-        DATAPROC=$(gcloud services list --enabled --format='table(NAME)[no-heading]' --project $proj | grep dataproc.googleapis.com)
+        DATAPROC=$($GCLOUD_CMD services list --enabled --format='table(NAME)[no-heading]' --project $proj | grep dataproc.googleapis.com)
         ERR=$?
         if [ $ERR -eq 0 ]
         then
-            for cluster in `gcloud dataproc clusters list --region $CLUSTER_REGION --format='table(NAME)[no-heading]' --project $proj`
+            for cluster in `$GCLOUD_CMD dataproc clusters list --region $CLUSTER_REGION --format='table(NAME)[no-heading]' --project $proj`
             do
                 # get the UTC time of the last status change for this cluster
-                LAST_STATUS=$(gcloud dataproc clusters describe --format='table(STATUS.stateStartTime)[no-heading]' --project $proj --region us-central1 $cluster | cut -f1 -d'.')
+                LAST_STATUS=$($GCLOUD_CMD dataproc clusters describe --format='table(STATUS.stateStartTime)[no-heading]' --project $proj --region us-central1 $cluster | cut -f1 -d'.')
 
                 # NOTE! this assumes the BSD date command on OS X.  Will likely need tweaks for GNU date on Linux.
                 SECONDS_AGO=$(( `date +%s` - `date -j -u -f '%Y-%m-%dT%H:%M:%S' $LAST_STATUS +%s` ))
@@ -58,7 +61,7 @@ for proj in `gcloud projects list --format='table(NAME)[no-heading]'`
                     if [[ "$ACTION" == "delete" ]]
                     then
                         echo "Deleting old cluster $cluster in $proj ... last updated $DAYS_AGO days ago"
-                        yes | gcloud dataproc clusters delete --async --region $CLUSTER_REGION --project $proj $cluster
+                        yes | $GCLOUD_CMD dataproc clusters delete --async --region $CLUSTER_REGION --project $proj $cluster
                         echo
                         echo "$proj,$cluster,$DAYS_AGO" >> $LOG_FILE
                     else


### PR DESCRIPTION
Enables the runner to run `gcloud` externally as a different user while this is running - which can take hours.