### PR TITLE
Update service account registration

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -74,7 +74,7 @@ class ProgressBar:
 
 def print_fields(obj):
     for item in vars(obj).items():
-        print (item)
+        print(item)
 
 
 class DefaultArgsParser:

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -59,12 +59,12 @@ class ProgressBar:
         width = 50
 
         bar_width = int(math.ceil(width * percent))
-        print "\r%s[%s%s] %s/%s %s" % (
+        print("\r%s[%s%s] %s/%s %s" % (
             "\t" * self.num_tabs, "=" * bar_width, " " * (width - bar_width), self.val.value, self.max,
-            self.description),
+            self.description)),
 
         if self.val.value >= max:
-            print "\n"
+            print("\n")
 
         sys.stdout.flush()
 
@@ -74,7 +74,7 @@ class ProgressBar:
 
 def print_fields(obj):
     for item in vars(obj).items():
-        print item
+        print (item)
 
 
 class DefaultArgsParser:
@@ -233,5 +233,5 @@ def prompt_to_continue(msg):
     elif choice in no:
         return False
     else:
-        print "Please respond with 'yes' or 'no'"
+        print("Please respond with 'yes' or 'no'")
         prompt_to_continue(msg)

--- a/scripts/register_service_account/register_service_account.py
+++ b/scripts/register_service_account/register_service_account.py
@@ -11,6 +11,10 @@ def main():
     parser.add_argument('-e', '--owner_email', dest='owner_email', action='store', required=True, help='Email address of the person who owns this service account')
     parser.add_argument('-u', '--url', dest='fc_url', action='store', default="https://api.firecloud.org", required=False, help='Base url of FireCloud server to contact (default https://api.firecloud.org)')
 
+    # Additional arguments
+    parser.add_argument('-f', '--first_name', dest='first_name', action='store', default="None", required=False, help='First name to register for user')
+    parser.add_argument('-l', '--last_name', dest='last_name', action='store', default="None", required=False, help='Last name to register for user')
+
     args = parser.parse_args()
 
     from oauth2client.service_account import ServiceAccountCredentials
@@ -21,13 +25,21 @@ def main():
 
     uri = args.fc_url + "/register/profile"
 
-    profile_json = {"firstName":"None", "lastName": "None", "title":"None", "contactEmail":args.owner_email,
-                               "institute":"None", "institutionalProgram": "None", "programLocationCity": "None", "programLocationState": "None",
-                               "programLocationCountry": "None", "pi": "None", "nonProfitStatus": "false"}
+    profile_json = {"firstName": args.first_name,
+                    "lastName": args.last_name,
+                    "title": "None",
+                    "contactEmail": args.owner_email,
+                    "institute": "None",
+                    "institutionalProgram": "None",
+                    "programLocationCity": "None",
+                    "programLocationState": "None",
+                    "programLocationCountry": "None",
+                    "pi": "None",
+                    "nonProfitStatus": "false"}
     request = requests.post(uri, headers=headers, json=profile_json)
 
     if request.status_code == 200:
-        print "The service account %s is now registered with FireCloud.  You can share workspaces with this address, or use it to call APIs." % credentials._service_account_email
+        print("The service account %s is now registered with FireCloud. You can share workspaces with this address, or use it to call APIs." % credentials._service_account_email)
     else:
         fail("Unable to register service account: %s" % request.text)
 


### PR DESCRIPTION
Ops periodically uses this script to register service accounts for use in Terra. This PR updates the script to allow the inclusion of first and last names, which helps us to keep the accounts more explicitly organized. These arguments are optional, and if they are not provided the values default to `"None"`, preserving the current behavior.

The second change is to add parenthesis to the print calls, in order to make them compatible with python 3.